### PR TITLE
Use grid for more predictable layout

### DIFF
--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -79,8 +79,7 @@ async function writeHTML() {
   <!DOCTYPE html>
   ${styleString}
   <style>
-    body { display: flex; flex-direction: row; flex-wrap: wrap; }
-    figure { flex: 1; }
+    body { display: grid; grid-template-columns: repeat(auto-fill, minmax(16em, 1fr)); grid-gap: 1em; }
     figure svg { height: 24px; width: 24px; }
   </style>
   ${svgsString}


### PR DESCRIPTION
This is a small layout tweak to ensure icons fit into a regular grid format. Here are some before/after shots. 

## Before
![wide](https://user-images.githubusercontent.com/22126/62089128-093c6d80-b225-11e9-8e1b-46fad1c4efc8.png)

## After 
![after-wide](https://user-images.githubusercontent.com/22126/62089137-12c5d580-b225-11e9-8b5a-d923ab57e367.png)

It also squishes down on small viewports. 

![after-thin](https://user-images.githubusercontent.com/22126/62089327-c5963380-b225-11e9-80ec-12e053f41f8e.png)

